### PR TITLE
Fix: When closing circles, dashedline can produce NaN coordinates

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -207,7 +207,7 @@ export class DashLine {
         }
         angle += interval
         for (let i = 1; i < points + 1; i++) {
-            const next = i === points ? first : [x + Math.cos(angle) * radius, y + Math.sin(angle) * radius]
+            const next = i === points ? [first.x, first.y] : [x + Math.cos(angle) * radius, y + Math.sin(angle) * radius]
             this.lineTo(next[0], next[1])
             angle += interval
         }


### PR DESCRIPTION
Thanks for this library! 

We found that when closing circles, the last segment could end up producing NaN coordinates.
The previous code was treating a PIXI.Point like a [number,number].

re https://github.com/rapideditor/pixi-dashed-line/issues/1
